### PR TITLE
Remove old reference to docker makefile

### DIFF
--- a/environment.mk
+++ b/environment.mk
@@ -1,5 +1,3 @@
-include docker.mk
-
 .PHONY: test
 
 DRUPAL_VER ?= 8


### PR DESCRIPTION
I assume it was there for convenience, but it's no longer needed after renaming docker.mk to Makefile.

The weird thing is, this is the first thing I tried when it first went red. But then I got another failure which I couldn't resolve. I've remerged develop and tried again and it Just Works :man_shrugging:. Let's check the PR build also goes green...