### PR TITLE
Use the correct image for mounting a codebase

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   php:
-    image: wodby/drupal:$DRUPAL_TAG
+    image: wodby/drupal-php:$PHP_TAG
     environment:
       ENVIRONMENT: docker
       DOCROOT_SUBDIR: docroot


### PR DESCRIPTION
This'll stop the annoying warnings `"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"` which were connected with it using PHP 7.3. It wasn't using the tag it should've been, so wasn't picking up the correct version to use.

See https://wodby.com/docs/stacks/drupal/local/#mount-my-codebase
See https://www.drupal.org/project/drupal/issues/3025014